### PR TITLE
fixes flaky logic in the pino logger

### DIFF
--- a/cloud_app/app/package.json
+++ b/cloud_app/app/package.json
@@ -11,9 +11,9 @@
   "author": "Charli Williams",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.6.8",
-    "express": "^4.19.2",
-    "googleapis": "^105.0.0",
-    "js-md5": "^0.8.3"
+    "axios": "^1.7.9",
+    "express": "^4.21.2",
+    "googleapis": "^144.0.0",
+    "js-md5": "0.8.3"
   }
 }

--- a/discord_bot/logging/index.js
+++ b/discord_bot/logging/index.js
@@ -150,7 +150,7 @@ const localisedLogging = (error, localArgs, globalDetails, trace = undefined) =>
 
   const path = filePath === "unknown" ? filePath : filePath.split("discord_bot/")[1]
   const fn = functionName === "unknown" ? functionName : functionName.replace("Object", path.split('/').pop().split('.js')[0])
-  const slashCommand = path === "unknown" ? slashCommand : path.split('/')[0] === 'commands'
+  const slashCommand = path === "unknown" ? path : path.split('/')[0] === 'commands'
 
   return logger.child({
     slashCommand,


### PR DESCRIPTION
Unclear how this has gone undetected for so long, but it errors if slashCommand is undefined