### PR TITLE
fix(api): amend to use environment variables for endpoint/passkey

### DIFF
--- a/discord_bot/functions/forms/fetchFormResponses.js
+++ b/discord_bot/functions/forms/fetchFormResponses.js
@@ -1,12 +1,15 @@
 const axios = require('axios');
 const { EmbedBuilder } = require('discord.js');
-const { apiEndpoint, apiPasskey } = require('../../config.json');
+const configFile = require('../../config.json');
 const { parse } = require('./parseFormResponses');
 const { hold } = require('./holdFormResponses');
 const { localisedLogging } = require('../../logging');
 
 exports.fetch = async (roundNumber) => {
   logger = localisedLogging(new Error(), arguments, this)
+  const apiPasskey = process.env.apiPasskey ? process.env.apiPasskey : configFile.apiPasskey
+  const apiEndpoint = process.env.apiEndpoint ? process.env.apiEndpoint : configFile.apiEndpoint
+  logger.info(`Using apiPasskey retrieved from ${process.env.apiPasskey ? "environment variable" : "config.json file"} and apiEndpoint retrieved from ${process.env.apiEndpoint ? "environment variable" : "config.json file"}`)
   const config = {
     headers: { Authorization: `Bearer ${apiPasskey}` }
   }


### PR DESCRIPTION
if the API endpoint or passkey changes, the docker image of v3.0.0 stable no longer works - this fix allows these variables to be passed into the container as environment variables