### PR TITLE
fix(error log): Issue#14 - tidy up error handling on quiz reset

### DIFF
--- a/discord_bot/functions/quiz/quizReset.js
+++ b/discord_bot/functions/quiz/quizReset.js
@@ -52,7 +52,12 @@ module.exports = (guild, blame='unknown') => {
   .then(({error, response}) => {
     logger.debug({error, response, deletions})
     if(error){
-      logger.info(`Firestore reset returned error:\n${JSON.stringify(error)}`)
+      logger.info(`
+        Firestore reset returned error:
+        ${JSON.stringify(error)}
+        This error can be safely ignored if there was no quiz today.
+      `.trim())
+      deletions["Firestore Mapping"] = 0;
     } else  {
       if(response.mappings.length > 0){
         deletions["Firestore Mapping"] = response.mappings;


### PR DESCRIPTION
The error was actually being safely consumed within the quiz reset function - have added some clarification to the error message, and provided a value for the reset message to display

cannot see that the error ever makes it to the front-end, so assuming that this ticket was raised following seeing the error in the logs.

closes #14 