### PR TITLE
fix(fetch all): Issue22 - handle errors better

### DIFF
--- a/discord_bot/functions/forms/fetchFormResponses.js
+++ b/discord_bot/functions/forms/fetchFormResponses.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const { EmbedBuilder } = require('discord.js');
 const configFile = require('../../config.json');
+const { check } = require('./checkPermissions');
 const { parse } = require('./parseFormResponses');
 const { hold } = require('./holdFormResponses');
 const { localisedLogging } = require('../../logging');
@@ -13,7 +14,12 @@ exports.fetch = async (roundNumber) => {
   const config = {
     headers: { Authorization: `Bearer ${apiPasskey}` }
   }
-  return axios.get(`${apiEndpoint}/responses/${roundNumber}`, config)
+
+  return check()
+  .then({error, response} => {
+    if(error){ throw error }
+    return axios.get(`${apiEndpoint}/responses/${roundNumber}`, config)
+  })
   .then(res => {
     if(res.data === undefined || res.data.length < 1){
       throw {message: `forms API response was ${JSON.stringify(res.data)}`, code: 404, loc: "fetchFormResponses.js/fetch():response"}
@@ -37,8 +43,13 @@ exports.fetch = async (roundNumber) => {
   .catch(error => {
     if(error.response){
       if(error.response.status === 403 && error.response.data){
+        logger.error("Google Apps Script was not authorised to handle request - reAuth required.")
         return {error: {code: 403, message: `Google Apps Script re-authorisation required at: ${error.response.data.reAuth}`}, response: null}
       }
+    }
+    if(error.code === 409 && error.reason){
+      logger.error(`${error.reason.replace("is", "was")} when called.`)
+      return {error: {code: error.code, message: error.reason}, response: null}
     }
     logger.error({...error});
     return {error, response: null};

--- a/discord_bot/functions/forms/parseFormResponses.js
+++ b/discord_bot/functions/forms/parseFormResponses.js
@@ -6,6 +6,10 @@ exports.parse = (data) => {
     return {error, response: null};
   }
 
+  if(data.error){
+    return {error: data.error, response: null}
+  }
+
   if(!data.roundDetails && !data.results) {
     const details = {data, loc: "parseFormResponses.js/parse()"};
     const error = {message: `forms API data malformed`, code: 400, details};


### PR DESCRIPTION
Check for authorisation of the API before doing any other calls

Catch nested error responses in parseForms()

Handle error 409 when a form is still open