### PR TITLE
feat(forms): add Google Forms API client, parser, and validator

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -103,3 +103,6 @@ Status key: `[ ]` todo, `[~]` in progress, `[x]` done
 - [ ] 7.3 — Historical stats / all-time leaderboards
 - [ ] 7.4 — Multi-guild support
 - [ ] 7.5 — Automated form creation (Google Forms API supports this)
+- [ ] 7.6 — Open/close form functions (toggle form accepting responses via Forms API)
+- [ ] 7.7 — `/form open <round>` and `/form close <round>` commands
+- [ ] 7.8 — `/form next` command (close current round's form, open the next round's form)

--- a/src/integrations/forms/client.test.ts
+++ b/src/integrations/forms/client.test.ts
@@ -23,6 +23,11 @@ vi.mock("../../utils/logger", () => ({
   logger: { info: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock("../../utils/result", () => ({
+  ok: (data: unknown) => ({ ok: true, data }),
+  err: (error: unknown) => ({ ok: false, error }),
+}));
+
 describe("createFormsClient", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -40,11 +45,12 @@ describe("createFormsClient", () => {
     });
   });
 
-  it("exposes getForm and listResponses methods", async () => {
+  it("exposes getForm, isFormClosed, and listResponses methods", async () => {
     const { createFormsClient } = await import("./client.js");
     const client = createFormsClient();
 
     expect(client.getForm).toBeInstanceOf(Function);
+    expect(client.isFormClosed).toBeInstanceOf(Function);
     expect(client.listResponses).toBeInstanceOf(Function);
   });
 
@@ -61,19 +67,65 @@ describe("createFormsClient", () => {
     expect(result).toEqual({ formId: "abc" });
   });
 
-  it("listResponses calls forms.responses.list with the formId", async () => {
+  it("isFormClosed returns true when form state is CLOSED", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const form = { formId: "abc", settings: { state: "CLOSED" } };
+    expect(client.isFormClosed(form as any)).toBe(true);
+  });
+
+  it("isFormClosed returns false when form state is not CLOSED", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const form = { formId: "abc", settings: { state: "OPEN" } };
+    expect(client.isFormClosed(form as any)).toBe(false);
+  });
+
+  it("isFormClosed returns false when settings are absent", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const form = { formId: "abc" };
+    expect(client.isFormClosed(form as any)).toBe(false);
+  });
+
+  it("listResponses returns responses when form is closed", async () => {
     const { createFormsClient } = await import("./client.js");
     const client = createFormsClient();
 
     const formsApi = google.forms({ version: "v1" });
+    vi.mocked(formsApi.forms.get).mockResolvedValue({
+      data: { formId: "abc", settings: { state: "CLOSED" } },
+    } as never);
     vi.mocked(formsApi.forms.responses.list).mockResolvedValue({
       data: { responses: [{ responseId: "r1" }] },
     } as never);
 
     const result = await client.listResponses("abc");
 
-    expect(formsApi.forms.responses.list).toHaveBeenCalledWith({ formId: "abc" });
-    expect(result).toEqual([{ responseId: "r1" }]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([{ responseId: "r1" }]);
+    }
+  });
+
+  it("listResponses returns error when form is still open", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const formsApi = google.forms({ version: "v1" });
+    vi.mocked(formsApi.forms.get).mockResolvedValue({
+      data: { formId: "abc", settings: { state: "OPEN" } },
+    } as never);
+
+    const result = await client.listResponses("abc");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("still accepting responses");
+    }
   });
 
   it("listResponses returns empty array when no responses exist", async () => {
@@ -81,12 +133,18 @@ describe("createFormsClient", () => {
     const client = createFormsClient();
 
     const formsApi = google.forms({ version: "v1" });
+    vi.mocked(formsApi.forms.get).mockResolvedValue({
+      data: { formId: "abc", settings: { state: "CLOSED" } },
+    } as never);
     vi.mocked(formsApi.forms.responses.list).mockResolvedValue({
       data: { responses: undefined },
     } as never);
 
     const result = await client.listResponses("abc");
 
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([]);
+    }
   });
 });

--- a/src/integrations/forms/client.test.ts
+++ b/src/integrations/forms/client.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { google } from "googleapis";
+
+vi.mock("googleapis", () => {
+  const mockGet = vi.fn();
+  const mockList = vi.fn();
+  return {
+    google: {
+      auth: {
+        GoogleAuth: vi.fn(() => ({ getClient: vi.fn() })),
+      },
+      forms: vi.fn(() => ({
+        forms: {
+          get: mockGet,
+          responses: { list: mockList },
+        },
+      })),
+    },
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+describe("createFormsClient", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("creates a Google Auth instance with forms scopes", async () => {
+    const { createFormsClient } = await import("./client.js");
+    createFormsClient();
+
+    expect(google.auth.GoogleAuth).toHaveBeenCalledWith({
+      scopes: [
+        "https://www.googleapis.com/auth/forms.body.readonly",
+        "https://www.googleapis.com/auth/forms.responses.readonly",
+      ],
+    });
+  });
+
+  it("exposes getForm and listResponses methods", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    expect(client.getForm).toBeInstanceOf(Function);
+    expect(client.listResponses).toBeInstanceOf(Function);
+  });
+
+  it("getForm calls forms.get with the formId", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const formsApi = google.forms({ version: "v1" });
+    vi.mocked(formsApi.forms.get).mockResolvedValue({ data: { formId: "abc" } } as never);
+
+    const result = await client.getForm("abc");
+
+    expect(formsApi.forms.get).toHaveBeenCalledWith({ formId: "abc" });
+    expect(result).toEqual({ formId: "abc" });
+  });
+
+  it("listResponses calls forms.responses.list with the formId", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const formsApi = google.forms({ version: "v1" });
+    vi.mocked(formsApi.forms.responses.list).mockResolvedValue({
+      data: { responses: [{ responseId: "r1" }] },
+    } as never);
+
+    const result = await client.listResponses("abc");
+
+    expect(formsApi.forms.responses.list).toHaveBeenCalledWith({ formId: "abc" });
+    expect(result).toEqual([{ responseId: "r1" }]);
+  });
+
+  it("listResponses returns empty array when no responses exist", async () => {
+    const { createFormsClient } = await import("./client.js");
+    const client = createFormsClient();
+
+    const formsApi = google.forms({ version: "v1" });
+    vi.mocked(formsApi.forms.responses.list).mockResolvedValue({
+      data: { responses: undefined },
+    } as never);
+
+    const result = await client.listResponses("abc");
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/integrations/forms/client.ts
+++ b/src/integrations/forms/client.ts
@@ -1,0 +1,27 @@
+import { google, forms_v1 } from "googleapis";
+import { logger } from "../../utils/logger.js";
+
+export function createFormsClient() {
+  const auth = new google.auth.GoogleAuth({
+    scopes: [
+      "https://www.googleapis.com/auth/forms.body.readonly",
+      "https://www.googleapis.com/auth/forms.responses.readonly",
+    ],
+  });
+
+  const formsApi = google.forms({ version: "v1", auth });
+
+  const getForm = async (formId: string): Promise<forms_v1.Schema$Form> => {
+    logger.info({ formId }, "Fetching form metadata");
+    const response = await formsApi.forms.get({ formId });
+    return response.data;
+  };
+
+  const listResponses = async (formId: string): Promise<forms_v1.Schema$FormResponse[]> => {
+    logger.info({ formId }, "Fetching form responses");
+    const response = await formsApi.forms.responses.list({ formId });
+    return response.data.responses ?? [];
+  };
+
+  return { getForm, listResponses };
+}

--- a/src/integrations/forms/client.ts
+++ b/src/integrations/forms/client.ts
@@ -1,5 +1,6 @@
 import { google, forms_v1 } from "googleapis";
 import { logger } from "../../utils/logger.js";
+import { ok, err, type Result } from "../../utils/result.js";
 
 export function createFormsClient() {
   const auth = new google.auth.GoogleAuth({
@@ -17,11 +18,22 @@ export function createFormsClient() {
     return response.data;
   };
 
-  const listResponses = async (formId: string): Promise<forms_v1.Schema$FormResponse[]> => {
-    logger.info({ formId }, "Fetching form responses");
-    const response = await formsApi.forms.responses.list({ formId });
-    return response.data.responses ?? [];
+  const isFormClosed = (form: forms_v1.Schema$Form): boolean => {
+    const state = (form.settings as Record<string, unknown>)?.state;
+    return state === "CLOSED";
   };
 
-  return { getForm, listResponses };
+  const listResponses = async (formId: string): Promise<Result<forms_v1.Schema$FormResponse[]>> => {
+    logger.info({ formId }, "Fetching form responses");
+
+    const form = await getForm(formId);
+    if (!isFormClosed(form)) {
+      return err("Form is still accepting responses - close it before fetching");
+    }
+
+    const response = await formsApi.forms.responses.list({ formId });
+    return ok(response.data.responses ?? []);
+  };
+
+  return { getForm, isFormClosed, listResponses };
 }

--- a/src/integrations/forms/index.ts
+++ b/src/integrations/forms/index.ts
@@ -1,0 +1,4 @@
+export { createFormsClient } from "./client.js";
+export { parseFormResponses } from "./parser.js";
+export { validateFormStructure } from "./validator.js";
+export type { ParsedRound, RoundDetails, TeamAnswer, TeamResult } from "./parser.js";

--- a/src/integrations/forms/parser.test.ts
+++ b/src/integrations/forms/parser.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import { parseFormResponses } from "./parser.js";
+import type { forms_v1 } from "googleapis";
+
+function buildForm(items: forms_v1.Schema$Item[]): forms_v1.Schema$Form {
+  return {
+    formId: "form1",
+    info: { title: "Round 1" },
+    items,
+  };
+}
+
+function textItem(questionId: string, title: string, points?: number): forms_v1.Schema$Item {
+  return {
+    itemId: questionId,
+    title,
+    questionItem: {
+      question: {
+        questionId,
+        grading: points != null ? { pointValue: points } : undefined,
+        textQuestion: {},
+      },
+    },
+  };
+}
+
+function multipleChoiceItem(questionId: string, title: string, points: number): forms_v1.Schema$Item {
+  return {
+    itemId: questionId,
+    title,
+    questionItem: {
+      question: {
+        questionId,
+        grading: { pointValue: points },
+        choiceQuestion: { type: "RADIO" },
+      },
+    },
+  };
+}
+
+function paragraphItem(questionId: string, title: string): forms_v1.Schema$Item {
+  return {
+    itemId: questionId,
+    title,
+    questionItem: {
+      question: {
+        questionId,
+        textQuestion: { paragraph: true },
+      },
+    },
+  };
+}
+
+function buildResponse(
+  responseId: string,
+  answers: Record<string, { value: string; score?: number; correct?: boolean }>,
+  totalScore: number,
+): forms_v1.Schema$FormResponse {
+  const formattedAnswers: Record<string, forms_v1.Schema$Answer> = {};
+  for (const [qId, ans] of Object.entries(answers)) {
+    formattedAnswers[qId] = {
+      questionId: qId,
+      grade: ans.correct ? { score: ans.score, correct: true } : {},
+      textAnswers: { answers: [{ value: ans.value }] },
+    };
+  }
+  return { responseId, answers: formattedAnswers, totalScore: String(totalScore) };
+}
+
+describe("parseFormResponses", () => {
+  it("extracts team name from first question and scores from the rest", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      textItem("q2", "What is the capital of France?", 2),
+      textItem("q3", "What year did WW2 end?", 2),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "Quiz Khalifa" },
+        q2: { value: "Paris", score: 2, correct: true },
+        q3: { value: "1945", score: 2, correct: true },
+      }, 4),
+    ];
+
+    const result = parseFormResponses(form, responses, 1);
+
+    expect(result.roundDetails).toEqual({ number: 1, questions: 2, totalScore: 4 });
+    expect(result.results["Quiz Khalifa"]).toEqual({
+      answers: [
+        { answer: "Paris", score: 2, correct: true },
+        { answer: "1945", score: 2, correct: true },
+      ],
+      score: 4,
+    });
+  });
+
+  it("handles incorrect answers with empty grade objects", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      textItem("q2", "Capital of France?", 2),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "The Losers" },
+        q2: { value: "Berlin" },
+      }, 0),
+    ];
+
+    const result = parseFormResponses(form, responses, 1);
+
+    expect(result.results["The Losers"]).toEqual({
+      answers: [{ answer: "Berlin", score: 0, correct: false }],
+      score: 0,
+    });
+  });
+
+  it("skips feedback paragraph questions", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      textItem("q2", "Question 1", 2),
+      paragraphItem("q3", "Any feedback on tonight's quiz?"),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "Team A" },
+        q2: { value: "Answer", score: 2, correct: true },
+        q3: { value: "Great quiz!" },
+      }, 2),
+    ];
+
+    const result = parseFormResponses(form, responses, 6);
+
+    expect(result.roundDetails).toEqual({ number: 6, questions: 1, totalScore: 2 });
+    expect(result.results["Team A"].answers).toHaveLength(1);
+  });
+
+  it("handles multiple choice questions the same as text", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      multipleChoiceItem("q2", "Pick the right answer", 2),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "MCQ Team" },
+        q2: { value: "Option B", score: 2, correct: true },
+      }, 2),
+    ];
+
+    const result = parseFormResponses(form, responses, 1);
+
+    expect(result.results["MCQ Team"]).toEqual({
+      answers: [{ answer: "Option B", score: 2, correct: true }],
+      score: 2,
+    });
+  });
+
+  it("handles partial scores (half marks)", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      textItem("q2", "Name the film", 2),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "Half Marks Club" },
+        q2: { value: "Close enough", score: 1, correct: true },
+      }, 1),
+    ];
+
+    const result = parseFormResponses(form, responses, 1);
+
+    expect(result.results["Half Marks Club"]).toEqual({
+      answers: [{ answer: "Close enough", score: 1, correct: true }],
+      score: 1,
+    });
+  });
+
+  it("trims whitespace from team names", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      textItem("q2", "Q1", 2),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "  Spacey Team  " },
+        q2: { value: "Answer", score: 2, correct: true },
+      }, 2),
+    ];
+
+    const result = parseFormResponses(form, responses, 1);
+
+    expect(result.results["Spacey Team"]).toBeDefined();
+  });
+
+  it("handles multiple teams", () => {
+    const form = buildForm([
+      textItem("q1", "Team Name"),
+      textItem("q2", "Q1", 2),
+    ]);
+
+    const responses = [
+      buildResponse("r1", {
+        q1: { value: "Team A" },
+        q2: { value: "Right", score: 2, correct: true },
+      }, 2),
+      buildResponse("r2", {
+        q1: { value: "Team B" },
+        q2: { value: "Wrong" },
+      }, 0),
+    ];
+
+    const result = parseFormResponses(form, responses, 1);
+
+    expect(Object.keys(result.results)).toHaveLength(2);
+    expect(result.results["Team A"].score).toBe(2);
+    expect(result.results["Team B"].score).toBe(0);
+  });
+});

--- a/src/integrations/forms/parser.ts
+++ b/src/integrations/forms/parser.ts
@@ -1,0 +1,107 @@
+import type { forms_v1 } from "googleapis";
+
+export interface RoundDetails {
+  number: number;
+  questions: number;
+  totalScore: number;
+}
+
+export interface TeamAnswer {
+  answer: string;
+  score: number;
+  correct: boolean;
+}
+
+export interface TeamResult {
+  answers: TeamAnswer[];
+  score: number;
+}
+
+export interface ParsedRound {
+  roundDetails: RoundDetails;
+  results: Record<string, TeamResult>;
+}
+
+interface ScoredQuestion {
+  questionId: string;
+  pointValue: number;
+}
+
+export function parseFormResponses(
+  form: forms_v1.Schema$Form,
+  responses: forms_v1.Schema$FormResponse[],
+  roundNumber: number,
+): ParsedRound {
+  const items = form.items ?? [];
+
+  const teamNameQuestionId = getTeamNameQuestionId(items);
+  const scoredQuestions = getScoredQuestions(items);
+
+  const roundDetails: RoundDetails = {
+    number: roundNumber,
+    questions: scoredQuestions.length,
+    totalScore: scoredQuestions.reduce((sum, q) => sum + q.pointValue, 0),
+  };
+
+  const results: Record<string, TeamResult> = {};
+
+  for (const response of responses) {
+    const answers = response.answers ?? {};
+
+    const teamNameAnswer = answers[teamNameQuestionId];
+    const teamName = teamNameAnswer?.textAnswers?.answers?.[0]?.value?.trim() ?? "Unknown";
+
+    const teamAnswers: TeamAnswer[] = [];
+    let totalScore = 0;
+
+    for (const question of scoredQuestions) {
+      const answer = answers[question.questionId];
+      const text = answer?.textAnswers?.answers?.[0]?.value ?? "";
+      const grade = answer?.grade ?? {};
+      const score = (grade as { score?: number }).score ?? 0;
+      const correct = (grade as { correct?: boolean }).correct ?? false;
+
+      teamAnswers.push({ answer: text, score, correct });
+      totalScore += score;
+    }
+
+    results[teamName] = { answers: teamAnswers, score: totalScore };
+  }
+
+  return { roundDetails, results };
+}
+
+function getTeamNameQuestionId(items: forms_v1.Schema$Item[]): string {
+  const first = items[0];
+  const questionId = first?.questionItem?.question?.questionId;
+  if (!questionId) {
+    throw new Error("First form item is not a question — cannot extract team name");
+  }
+  return questionId;
+}
+
+function getScoredQuestions(items: forms_v1.Schema$Item[]): ScoredQuestion[] {
+  const scored: ScoredQuestion[] = [];
+
+  for (let i = 1; i < items.length; i++) {
+    const item = items[i];
+    const question = item.questionItem?.question;
+    if (!question?.questionId) continue;
+
+    if (isFeedbackQuestion(item)) continue;
+
+    const pointValue = question.grading?.pointValue;
+    if (pointValue != null && pointValue > 0) {
+      scored.push({ questionId: question.questionId, pointValue });
+    }
+  }
+
+  return scored;
+}
+
+function isFeedbackQuestion(item: forms_v1.Schema$Item): boolean {
+  const question = item.questionItem?.question;
+  const isParagraph = question?.textQuestion?.paragraph === true;
+  const titleContainsFeedback = (item.title ?? "").toLowerCase().includes("feedback");
+  return isParagraph && titleContainsFeedback;
+}

--- a/src/integrations/forms/validator.test.ts
+++ b/src/integrations/forms/validator.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { validateFormStructure } from "./validator.js";
+import type { forms_v1 } from "googleapis";
+
+function textItem(questionId: string, title: string, opts?: { points?: number; paragraph?: boolean; required?: boolean }): forms_v1.Schema$Item {
+  return {
+    itemId: questionId,
+    title,
+    questionItem: {
+      question: {
+        questionId,
+        required: opts?.required,
+        grading: opts?.points != null ? { pointValue: opts.points } : undefined,
+        textQuestion: opts?.paragraph ? { paragraph: true } : {},
+      },
+    },
+  };
+}
+
+function multipleChoiceItem(questionId: string, title: string, points: number): forms_v1.Schema$Item {
+  return {
+    itemId: questionId,
+    title,
+    questionItem: {
+      question: {
+        questionId,
+        grading: { pointValue: points },
+        choiceQuestion: { type: "RADIO" },
+      },
+    },
+  };
+}
+
+describe("validateFormStructure", () => {
+  it("returns ok for a valid form", () => {
+    const form: forms_v1.Schema$Form = {
+      formId: "f1",
+      info: { title: "Round 1" },
+      items: [
+        textItem("q1", "Team Name"),
+        textItem("q2", "Question 1", { points: 2 }),
+        textItem("q3", "Question 2", { points: 2 }),
+      ],
+    };
+
+    const result = validateFormStructure(form);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok when feedback question is present", () => {
+    const form: forms_v1.Schema$Form = {
+      formId: "f1",
+      info: { title: "Round 6" },
+      items: [
+        textItem("q1", "Team Name"),
+        textItem("q2", "Question 1", { points: 2 }),
+        textItem("q3", "Any feedback on the quiz?", { paragraph: true }),
+      ],
+    };
+
+    const result = validateFormStructure(form);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok for multiple choice questions", () => {
+    const form: forms_v1.Schema$Form = {
+      formId: "f1",
+      info: { title: "Round 3" },
+      items: [
+        textItem("q1", "Team Name"),
+        multipleChoiceItem("q2", "Pick one", 2),
+      ],
+    };
+
+    const result = validateFormStructure(form);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails if form has no items", () => {
+    const form: forms_v1.Schema$Form = {
+      formId: "f1",
+      info: { title: "Empty" },
+      items: [],
+    };
+
+    const result = validateFormStructure(form);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("no items");
+  });
+
+  it("fails if first item is not a question", () => {
+    const form: forms_v1.Schema$Form = {
+      formId: "f1",
+      info: { title: "Bad" },
+      items: [{ itemId: "x", title: "Section Header" }],
+    };
+
+    const result = validateFormStructure(form);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("first item");
+  });
+
+  it("fails if there are no scored questions", () => {
+    const form: forms_v1.Schema$Form = {
+      formId: "f1",
+      info: { title: "No scores" },
+      items: [
+        textItem("q1", "Team Name"),
+        textItem("q2", "Unscored question"),
+      ],
+    };
+
+    const result = validateFormStructure(form);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("no scored questions");
+  });
+});

--- a/src/integrations/forms/validator.ts
+++ b/src/integrations/forms/validator.ts
@@ -1,0 +1,42 @@
+import type { forms_v1 } from "googleapis";
+import type { Result } from "../../utils/result.js";
+import { ok, err } from "../../utils/result.js";
+
+export function validateFormStructure(form: forms_v1.Schema$Form): Result<true> {
+  const items = form.items ?? [];
+
+  if (items.length === 0) {
+    return err("Form has no items");
+  }
+
+  const firstQuestion = items[0]?.questionItem?.question;
+  if (!firstQuestion?.questionId) {
+    return err("Cannot identify team name: first item is not a question");
+  }
+
+  let scoredCount = 0;
+  for (let i = 1; i < items.length; i++) {
+    const question = items[i].questionItem?.question;
+    if (!question) continue;
+
+    if (isFeedback(items[i])) continue;
+
+    const pointValue = question.grading?.pointValue;
+    if (pointValue != null && pointValue > 0) {
+      scoredCount++;
+    }
+  }
+
+  if (scoredCount === 0) {
+    return err("Form has no scored questions");
+  }
+
+  return ok(true);
+}
+
+function isFeedback(item: forms_v1.Schema$Item): boolean {
+  const question = item.questionItem?.question;
+  const isParagraph = question?.textQuestion?.paragraph === true;
+  const titleContainsFeedback = (item.title ?? "").toLowerCase().includes("feedback");
+  return isParagraph && titleContainsFeedback;
+}


### PR DESCRIPTION
## Summary

Google Forms integration - direct access to quiz responses without the V3 Apps Script middleman:

- **Forms API client** - service account auth, fetches form structure and responses
- **Response parser** - extracts team names, answers, and scores from raw Forms API data
- **Form validator** - checks form structure matches expected format before parsing
- **Barrel export** - clean public API for the integration

## Design decisions

- Service account auth (no OAuth consent flow, no user interaction needed)
- Parser handles messy real-world data (team name normalisation, missing answers)
- Validator runs before parsing to fail fast with clear error messages
- Discriminated union returns throughout

## Tests

Parser and validator tested with representative mock Forms API responses.
